### PR TITLE
Made changes to get_station_data and associated function, including n…

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,3 +15,4 @@ max-locals=20
 min-public-methods=0
 fail-under=9.5
 extension-pkg-allow-list=pydantic
+max-branches=20

--- a/src/common/pg_impl.py
+++ b/src/common/pg_impl.py
@@ -276,7 +276,7 @@ class PGImplementation(PGUtilsMultiConnect):
         :return:
         """
         # get forecast data
-        forecast_data = self.get_forecast_station_data(kwargs['station_name'], kwargs['time_mark'], kwargs['data_source'])
+        forecast_data = self.get_forecast_station_data(kwargs['station_name'], kwargs['time_mark'], kwargs['data_source'], kwargs['instance_name'])
 
         # derive start date from the time mark
         start_date = (datetime.fromisoformat(kwargs['time_mark']) - timedelta(4)).isoformat()
@@ -290,7 +290,7 @@ class PGImplementation(PGUtilsMultiConnect):
 
         # get nowcast data_source from forecast data_source
         # check if data_source is tropical
-        if kwargs['data_source'][:2] == 'al':
+        if kwargs['forcing_metaclass'] == 'tropical':
             # if tropical split data source and replace second value (OFCL) with NOWCAST
             source_parts = kwargs['data_source'].split('_')
             source_parts[1] = 'NOWCAST'
@@ -299,16 +299,31 @@ class PGImplementation(PGUtilsMultiConnect):
             # if synoptic split data source and replace fist value (GFSFORECAST) with NOWCAST
             nowcast_source = 'NOWCAST_' + "_".join(kwargs['data_source'].split('_')[1:])
 
-        # get obs and nowcast data
-        obs_data = self.get_obs_station_data(kwargs['station_name'], start_date, end_date, nowcast_source)
+        # get obs data
+        obs_data = self.get_obs_station_data(kwargs['station_name'], start_date, end_date)
 
         # drop empty columns
         empty_cols = [col for col in obs_data.columns if obs_data[col].isnull().all()]
         obs_data.drop(empty_cols, axis=1, inplace=True)
 
+        # get nowcast data
+        nowcast_data = self.get_nowcast_station_data(kwargs['station_name'], start_date, end_date, nowcast_source, kwargs['instance_name'])
+
+        # If nowcast data exists merge it with obs data
+        if not nowcast_data.empty:
+            obs_data = obs_data.merge(nowcast_data, on='time_stamp', how='outer')
+        else:
+            obs_data = obs_data
+
         # replace any None values with np.nan, in both DataFrames
         forecast_data.fillna(value=np.nan)
         obs_data.fillna(value=np.nan)
+
+        # replace any -99999 values with np.nan, in both DataFrames
+        fcols = forecast_data.columns.tolist()
+        forecast_data[fcols] = forecast_data[fcols].replace([-99999], np.nan)
+        ocols = obs_data.columns.tolist()
+        obs_data[ocols] = obs_data[ocols].replace([-99999], np.nan)
 
         # convert all values after the time mark to nan, in obs data, except in the time_stamp and tidal_predictions columns
         for col in obs_data.columns:
@@ -353,13 +368,14 @@ class PGImplementation(PGUtilsMultiConnect):
         # return the data to the caller
         return station_df.to_csv(index=False)
 
-    def get_forecast_station_data(self, station_name, time_mark, data_source) -> pd.DataFrame:
+    def get_forecast_station_data(self, station_name, time_mark, data_source, instance_name) -> pd.DataFrame:
         """
         Gets the forcast station data
 
         :param station_name:
         :param time_mark:
         :param data_source:
+        :param instance_name:
         :return:
         """
         # init the return value:
@@ -367,7 +383,7 @@ class PGImplementation(PGUtilsMultiConnect):
 
         # Run query
         sql = f"SELECT * FROM get_forecast_timeseries_station_data(_station_name := '{station_name}', _timemark := '{time_mark}', " \
-              f"_data_source := '{data_source}')"
+              f"_data_source := '{data_source}',  _source_instance := '{instance_name}')"
 
         # get the info
         station_data = self.exec_sql('apsviz_gauges', sql)
@@ -382,7 +398,38 @@ class PGImplementation(PGUtilsMultiConnect):
         # Return Pandas dataframe
         return ret_val
 
-    def get_obs_station_data(self, station_name, start_date, end_date, nowcast_source) -> pd.DataFrame:
+    def get_nowcast_station_data(self, station_name, start_date, end_date, data_source, instance_name) -> pd.DataFrame:
+        """
+        Gets the forcast station data
+
+        :param station_name:
+        :param start_date:
+        :param end_data:
+        :param data_source:
+        :param instance_name:
+        :return:
+        """
+        # init the return value:
+        ret_val: pd.DataFrame = pd.DataFrame()
+
+        # Run query
+        sql = f"SELECT * FROM get_nowcast_timeseries_station_data(_station_name := '{station_name}', _start_date := '{start_date}', " \
+              f"_end_date := '{end_date}', _data_source := '{data_source}',  _source_instance := '{instance_name}')"
+
+        # get the info
+        station_data = self.exec_sql('apsviz_gauges', sql)
+
+        # was it successful
+        if station_data != -1:
+            # convert query output to Pandas dataframe
+            ret_val = pd.DataFrame.from_dict(station_data, orient='columns')
+        else:
+            ret_val = pd.DataFrame(None)
+
+        # Return Pandas dataframe
+        return ret_val
+
+    def get_obs_station_data(self, station_name, start_date, end_date) -> pd.DataFrame:
         """
         Gets the observed station data.
 
@@ -396,8 +443,8 @@ class PGImplementation(PGUtilsMultiConnect):
         ret_val: pd.DataFrame = pd.DataFrame()
 
         # build the query
-        sql = f"SELECT * FROM get_obs_timeseries_station_data(_station_name := '{station_name}', _start_date := '{start_date}', _end_date := " \
-              f"'{end_date}', _nowcast_source := '{nowcast_source}')"
+        sql = f"SELECT * FROM get_obs_timeseries_station_data(_station_name := '{station_name}', _start_date := '{start_date}', " \
+              f"_end_date := '{end_date}')"
 
         # get the info
         station_data = self.exec_sql('apsviz_gauges', sql)

--- a/src/common/pg_impl.py
+++ b/src/common/pg_impl.py
@@ -312,8 +312,6 @@ class PGImplementation(PGUtilsMultiConnect):
         # If nowcast data exists merge it with obs data
         if not nowcast_data.empty:
             obs_data = obs_data.merge(nowcast_data, on='time_stamp', how='outer')
-        else:
-            obs_data = obs_data
 
         # replace any None values with np.nan, in both DataFrames
         forecast_data.fillna(value=np.nan)

--- a/src/server.py
+++ b/src/server.py
@@ -397,7 +397,8 @@ async def get_terria_map_catalog_data_file(file_name: Union[str, None] = Query(d
 
 @APP.get('/get_station_data', status_code=200, response_model=None, response_class=PlainTextResponse)
 def get_station_data(station_name: Union[str, None] = Query(default=None), time_mark: Union[str, None] = Query(default=None),
-                     data_source: Union[str, None] = Query(default=None)) -> PlainTextResponse:
+                     data_source: Union[str, None] = Query(default=None), instance_name: Union[str, None] = Query(default=None),
+                     forcing_metaclass: Union[str, None] = Query(default=None)) -> PlainTextResponse:
     """
     Returns the CSV formatted observational station.
 
@@ -412,12 +413,12 @@ def get_station_data(station_name: Union[str, None] = Query(default=None), time_
     # example input - station name: 8651370, timemark: 2023-08-24T00:00:00, data_source: GFSFORECAST_WNAT_53K_V1.0
     try:
         # validate the input. nothing is optional
-        if station_name or time_mark or data_source:
+        if station_name or time_mark or data_source or instance_name or forcing_metaclass:
             # init the kwargs variable
             kwargs: dict = {}
 
             # create the param list
-            params: list = ['station_name', 'time_mark', 'data_source']
+            params: list = ['station_name', 'time_mark', 'data_source', 'instance_name', 'forcing_metaclass']
 
             # loop through the SP params passed in
             for param in params:


### PR DESCRIPTION
The changes made in this branch pertain to the server.py and pg_impl.py scripts. A new method for getting the nowcast data, which uses a new SP get_nowcast_timeseries_station_data, has been added, and the existing method to get the obs data, which uses the SP get_obs_timeseries_station_data, has been modified to not get the nowcast data. 

In addition the method of getting forecast data, which uses the existing SP get_forecast_timeseries_station_data, has been modified to use an instance_name in the query to get the data. This enables differentiating between ADCIRC instances that have the same start time, grid name and forcing ensemble name. The instance name is also used in the method that gets the nowcast data. 

All three SPs get_obs_timeseries_station_data, get_forecast_timeseries_station_data and get_nowcast_timeseries_station_data have been modified in accordance with the changes described above.

The addition of the instance_name has changed the input url used by these script. Another variable forcing_metaclass has also been added to the input url. The use of the instance_name is described above. The forcing_metaclass is used in the script to differentiate between tropical and synoptic runs. Changes to the get_station_data function in sever.py have been made to process these new variables and pass them to the get_station_data function in pg_impl.py where they are used to process the data.